### PR TITLE
my suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ To provide each project with expectable folder structure it will be fixed in the
 ### Main folder structure approved ([Approving Poll](https://discord.com/channels/795728654566817812/795778114139586590/796050026689855538))
 
 - gym
+- raid_egg
 - raid
 - invasion
 - pokemon
@@ -36,30 +37,38 @@ To provide each project with expectable file name it will be fixed in the standa
 - ~~Hyphen~~, ### Underscore ### or ~~Nothing~~ ([Approving Poll](https://discord.com/channels/795728654566817812/797833971332415529/805465450863394847))
 - Order of variables ([Approving Poll](https://discord.com/channels/795728654566817812/797833971332415529/805466387342426114))
 
-  - `<pokemon id>[_e{temp evolution id}][_f{form id}][_c{costume id}][_g{gender id}][_s].png`
+  - `<pokemon id>[_s][_e{temp evolution id}][_f{form id}][_c{costume id}][_g{gender id}].png`
     - Example: `3.png` Regular Venusaur
     - Example: `3_e1_s.png` Mega Venusaur Shiny
     - Example: `3_f950.png` Venusaur Clone Form
+    - s = whether or not it's shiny
 
 ### Reward icons ( ALL BELOW IS A PROPOSAL )
-  - item: `<item id>[_a{ammount}].png`
+  - item: `<item id>[_a{amount}].png`
   - stardust:`<amount>.png`
-  - mega_resouce:`<pokemon id>.png`
+  - mega_resouce:`<pokemon id>[_a{amount}].png`
+    - amount is absolutely not required
 ### Gym icons
-  - gym: `<team id>[_t{trainer count}][_b{battle}][_e{ex}].png`
+  - gym: `<team id>[_t{trainer count}][_e][_b].png`
+  - e = whether the gym is ex eligible, b = whether the gym is in battle
+### Raid egg icons
+  - raid: `<egg level>[_h][_e].png`
+    - e = whether or not the egg is for an ex raid 
+    - h = whether the egg has hatched
 ### Raid icons
-  - raid: `<egg level>[_h{hatched}][_e {ex}].png`
+  - raid: `<raid level>.png`
 ### Invasion icons
   - invasion: `<grunt id>.png`
 ### Pokestop icons
-  - pokestop: `<lure id**>[_i][_q].png` ( `_i` invasion active `_q` quest active ) images from invasion and reward folder can be used as overlay
+  - pokestop: `0<_l{lure id}**>[_i][_q].png` ( `_i` invasion active `_q` quest active ) images from invasion and reward folder can be used as overlay
   - ** Not lured is ID `0` further follow proto's
-  - *** To be considered `[_s{small}][_b{big}]` (Small icons minimal details eg marker use. Big icons full details eg label notification use)
+  - *** To be considered `[_s{small}][_b{big}]` (Small icons minimal details eg marker use. Big icons full details eg label notification use) (if so, we should have something similiar for gyms)
 ### Team Icons
   - team: `<team id>.png` (Team badges not to be confused with Gym icons)
 ### Type Icons
   - type: `<type id>.png` 
 ### Weather Icons
   - weather: `<weather id>[_l{severity level}].png`
+  - do we want different colors? e.g. blue, black, white. do we also want to have more detailed icons? (the ones you see when clicking on the weather screen in-game)
 ### Misc Icons
   - Folder to for any icons that dont fit any category and do not pose the need for additional category.


### PR DESCRIPTION
These are my suggestions.

- Boolean values should just be _x without a number following the letter
- Have raid_egg and raid categories: raid is a more generic symbol for raids (think the rhydon or lugia head from the game)
- move _s to the front of pokemon.
  - If an icon repo has no shiny sprites (which most won't) it's uneffected
  - If you want to show a notification for a shiny santa pikachu, but the repo you're using only has normal shiny pikachu and normal santa pikachu, the notification should have a shiny normal pikachu, not a normal santa pikachu
- mega energy should have an amount flag, since quests can have different amounts of mega energy (i don't expect anyone to add all the variations tho, but it's nice to have)
- we already discussed stop icons, but i'd prefer to have a leading 0 (instead of the lure) for future-proofing (stop levels that WILL come)
- and for weather a suggestion: do we want different colors? e.g. blue, black, white. do we also want to have more detailed icons? (the ones you see when clicking on the weather screen in-game)