### PR TITLE
x instead of ex

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
   - stardust:`<amount>.png`
   - mega_resouce:`<pokemon id>.png`
 ### Gym icons ([Approving Poll](https://discord.com/channels/795728654566817812/797833971332415529/849751311003418674))
-  - gym: `<team id>[_t{trainer count}][_b][_ex].png` (`_b` in active battle `_ex` ex gym (no flag means false))
+  - gym: `<team id>[_t{trainer count}][_b][_x].png` (`_b` in active battle `_x` ex gym (no flag means false))
 ### Raid icons  ( ALL BELOW IS A PROPOSAL )
-  - raid: `<egg level>[_h][_ex].png` (`_h` hatched egg `_ex` ex gym (no flag means false))
+  - raid: `<egg level>[_h][_x].png` (`_h` hatched egg `_x` ex gym (no flag means false))
 ### Invasion icons
   - invasion: `<grunt id>.png`
 ### Pokestop icons


### PR DESCRIPTION
<!--- Edit README.mb to show what you want to change -->
<!--- This pr will result in a poll on Discord. If you get the majority on your side it will be included in the standard -->
<!--- Please create a seperate pull request for each of the changes you want where possible. Polls are done for the complete pr -->

## Describe why this should be changed or added
_ex is the only flag that consisting of 2 letters. To make it consistent with the rest of UICON naming styles, it should be 1 letter instead.

## Describe alternatives you've considered
Any letter is fine by me. I'd prefer _e myself, but Wheel it could get mixed up with a Pokemon's mega/temp evolution flag. 

## Additional context
- [mentioned in discord](https://discord.com/channels/795728654566817812/795778114139586590/849783689159770152)
- mentioned in [my first pr](https://github.com/UIcons/UIcons/pull/1)
