### PR TITLE
raid_egg instead of raid

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
 ### Main folder structure approved ([Approving Poll](https://discord.com/channels/795728654566817812/795778114139586590/796050026689855538))
 
 - gym
-- raid
+- raid_egg
 - invasion
 - pokemon
 - pokestop
@@ -45,7 +45,7 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
   - mega_resouce:`<pokemon id>.png`
 ### Gym icons ([Approving Poll](https://discord.com/channels/795728654566817812/797833971332415529/849751311003418674))
   - gym: `<team id>[_t{trainer count}][_b][_ex].png` (`_b` in active battle `_ex` ex gym (no flag means false))
-### Raid icons  ( ALL BELOW IS A PROPOSAL )
+### Raid egg icons  ( ALL BELOW IS A PROPOSAL )
   - raid: `<egg level>[_h][_ex].png` (`_h` hatched egg `_ex` ex gym (no flag means false))
 ### Invasion icons
   - invasion: `<grunt id>.png`


### PR DESCRIPTION
<!--- Edit README.mb to show what you want to change -->
<!--- This pr will result in a poll on Discord. If you get the majority on your side it will be included in the standard -->
<!--- Please create a seperate pull request for each of the changes you want where possible. Polls are done for the complete pr -->

## Describe why this should be changed or added
The icons that are called `raid` right now are just raid eggs. To make this more clear, change the folder name.

This could allow for a new `raid` category that has actual raid icons, not just raid eggs. E.g. in PMSF these could be used instead of hatched eggs in the Raid filter.

## Describe alternatives you've considered
Would be fine with any name that makes it clear these icons are raid eggs. 

## Additional context
- [mentioned early january in discord](https://discord.com/channels/795728654566817812/795778114139586590/797492925004251137) wheel said we should not call it that "In case niantic adds more raid types". Obviously we don't know what Niantic is doing, but if they're adding new non-egg Raids, the current naming style wouldn't work anyway and we'd have to come up with something else
- [mentioned while discussing my first pr](https://discord.com/channels/795728654566817812/795778114139586590/839996000721829888) with wheel
- [mentioned early january in discord](https://discord.com/channels/795728654566817812/795728654566817817/795800759995727912) with no additional discussion
- [mentioned in discord](https://discord.com/channels/795728654566817812/795778114139586590/848678473278685235) with no additional discussion
- [mentioned in my pr](https://github.com/UIcons/UIcons/pull/1)
