### PR TITLE
Stop icons shouldn't start with lure id

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
 ### Invasion icons
   - invasion: `<grunt id>.png`
 ### Pokestop icons
-  - pokestop: `0<_l{lure id}>[_i][_q].png` ( `_i` invasion active `_q` quest active ) images from invasion and reward folder can be used as overlay
+  - pokestop: `0<_l[lure id]>[_i][_q].png` ( `_i` invasion active `_q` quest active ) images from invasion and reward folder can be used as overlay
   - Upcoming Pokestop levels might change perspective on pokestop icon naming.. TBC
 ### Team Icons
   - team: `<team id>.png` (Team badges not to be confused with Gym icons)

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
 ### Invasion icons
   - invasion: `<grunt id>.png`
 ### Pokestop icons
-  - pokestop: `0_l<lure id**>[_i][_q].png` ( `_i` invasion active `_q` quest active ) images from invasion and reward folder can be used as overlay
-  - ** Not lured is ID `0` further follow proto's
+  - pokestop: `0<_l{lure id}>[_i][_q].png` ( `_i` invasion active `_q` quest active ) images from invasion and reward folder can be used as overlay
   - Upcoming Pokestop levels might change perspective on pokestop icon naming.. TBC
 ### Team Icons
   - team: `<team id>.png` (Team badges not to be confused with Gym icons)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
 ### Invasion icons
   - invasion: `<grunt id>.png`
 ### Pokestop icons
-  - pokestop: `<lure id**>[_i][_q].png` ( `_i` invasion active `_q` quest active ) images from invasion and reward folder can be used as overlay
+  - pokestop: `0_l<lure id**>[_i][_q].png` ( `_i` invasion active `_q` quest active ) images from invasion and reward folder can be used as overlay
   - ** Not lured is ID `0` further follow proto's
   - Upcoming Pokestop levels might change perspective on pokestop icon naming.. TBC
 ### Team Icons


### PR DESCRIPTION
<!--- Edit README.mb to show what you want to change -->
<!--- This pr will result in a poll on Discord. If you get the majority on your side it will be included in the standard -->
<!--- Please create a seperate pull request for each of the changes you want where possible. Polls are done for the complete pr -->

## Describe why this should be changed or added
Currently, all UICONS begin with a number that are a "base" for that icon. Like how Pokemon start with the Mon ID, Gyms start with the Team ID or Raid Eggs start with the raid level. All other flags are then addons/overlays/slight variations for that icon. Like how Bulbasaur is getting costumes, how a gym can different levels or how a Raid egg can have different levels.

Personally, I see lures on Stops as addons/overlays/slight variations. So to make the icon names consistent, lures should be flags, which leaves us with a base. And in my eyes, Stops have no clear "base", so Stop icons should just start with 0.

Additionally, this might future-proof icon naming for possible Stop levels, which have been datamined before.

## Describe alternatives you've considered
This is just an idea. Having lures as a base makes sense and i'd be fine with it.

## Additional context
![](https://media.discordapp.net/attachments/627584909174767627/829483451413037137/PoweUpPokestops.png)

The datamined assets make it seem like leveled up Stops look bigger in-game, which would give us a clear base for icons.
