### PR TITLE
Raid folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
 ### Main folder structure approved ([Approving Poll](https://discord.com/channels/795728654566817812/795778114139586590/796050026689855538))
 
 - gym
-- raid_egg
+- raid
+  - egg 
 - invasion
 - pokemon
 - pokestop
@@ -49,8 +50,8 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
   - xl_candy:`<pokemon id>[_a{amount}].png`
 ### Gym icons ([Approving Poll](https://discord.com/channels/795728654566817812/797833971332415529/849751311003418674))
   - gym: `<team id>[_t{trainer count}][_b][_ex].png` (`_b` in active battle `_ex` ex gym (no flag means false))
-### Raid egg icons ([Approving Poll](https://discord.com/channels/795728654566817812/797833971332415529/854382259615432725))
-  - raid: `<egg level>[_h][_ex].png` (`_h` hatched egg `_ex` ex gym (no flag means false))
+### Raid icons 
+  - egg: `<egg level>[_h][_ex].png` (`_h` hatched egg `_ex` ex gym (no flag means false))
 ### Invasion icons ([Approving Poll](https://discord.com/channels/795728654566817812/797833971332415529/854385467733573663))
   - invasion: `<grunt id>.png`
 ### Pokestop icons ([Approving Poll](https://discord.com/channels/795728654566817812/797833971332415529/854389589140832276))


### PR DESCRIPTION
<!--- Edit README.mb to show what you want to change -->
<!--- This pr will result in a poll on Discord. If you get the majority on your side it will be included in the standard -->
<!--- Please create a seperate pull request for each of the changes you want where possible. Polls are done for the complete pr -->

## Describe why this should be changed or added
Since the poll was a draw. 

`raid_egg` severely limits the use of this folder. Any future raid related icons that not fit `raid_egg` will require a new folder, making the UICONS root messy.

By naming the root folder `raid` and subfolder `egg` to categorize them would allow for more flexibility for the `raid` folder.

## Describe alternatives you've considered
`raid` root folder and prefixes such as `egg_` to distinguish different categories so there is no need for subfolders.

`egg_<egg level>[_h][_ex].png` (`_h` hatched egg `_ex` ex gym (no flag means false))

## Additional context
Add any other context here.
