### PR TITLE
Add Mega Amounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
 ### Reward icons ([Approving Poll](https://discord.com/channels/795728654566817812/797833971332415529/848220938838343690)) (ongoing discussion about amount for mega_resource)
   - item: `<item id>[_a{amount}].png`
   - stardust:`<amount>.png`
-  - mega_resouce:`<pokemon id>.png`
+  - mega_resouce:`<pokemon id>[_a{amount}].png`
   - candy: `<pokemon id>[_a{amount}].png`
   - xl_candy:`<pokemon id>[_a{amount}].png`
 ### Gym icons ([Approving Poll](https://discord.com/channels/795728654566817812/797833971332415529/849751311003418674))
@@ -65,7 +65,7 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
 ### Weather Icons ([Approving Poll](https://discord.com/channels/795728654566817812/797833971332415529/854388585050013726))
   - weather: `<weather id>[_l{severity level}].png`
 ### Misc Icons
-  - Folder to for any icons that dont fit any category and do not pose the need for additional category.
+  - Folder to for any icons that don't fit any category and do not pose the need for additional category.
 
 ## Credits:  
 - [Mygod](https://github.com/Mygod/pokemon-icon-postprocessor) for basic concept


### PR DESCRIPTION
<!--- Edit README.mb to show what you want to change -->
<!--- This pr will result in a poll on Discord. If you get the majority on your side it will be included in the standard -->
<!--- Please create a seperate pull request for each of the changes you want where possible. Polls are done for the complete pr -->

## Describe why this should be changed or added
If we're supporting amounts for items, we may as well support amounts for mega_resources, for the services that offer those details. There are significantly less required images compared to amounts for items. Examples can be viewed here:
https://github.com/WatWowMap/wwm-uicons/tree/main/reward/mega_resource

## Describe alternatives you've considered
What are alternatives :lappy: