### PR TITLE
Optional Weather Day/Night Flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
 ### Nest Icons
   - nest: `<type id>.png` 
 ### Weather Icons
-  - weather: `<weather id>[_l{severity level}].png`
+  - weather: `<weather id>[_l{severity level}][_d][_n].png`
 ### Misc Icons
   - Folder to for any icons that don't fit any category and do not pose the need for additional category.
 


### PR DESCRIPTION
Adds optional flags to weather for supporting day and night image variations

[Example Image Repo](https://github.com/WatWowMap/wwm-uicons/tree/main/weather)

[Example Implementation](https://github.com/WatWowMap/ReactMap/pull/238/files#diff-470e18059f0603a8648588815b6ce3c9d9a017b1b1657c46545e4ac918646e54)

<!--- Edit README.mb to show what you want to change -->
<!--- This pr will result in a poll on Discord. If you get the majority on your side it will be included in the standard -->
<!--- Please create a seperate pull request for each of the changes you want where possible. Polls are done for the complete pr -->

## Describe why this should be changed or added
Provides a better experience for end users to see accurate weather icons that reflect the in game weather status.

## Describe alternatives you've considered
I'm open to alternative flags, my PR for ReactMap is still open and adjustable. Fairly certain no one is using the `_d` `_n` images in my UICONS repo so that's also adjustable.
