### PR TITLE
Add Support for Gold Pokéstop (`incident_display_type`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,16 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
 ### Raid icons 
   - egg: `<egg level>[_h][_ex].png` (`_h` hatched egg `_ex` ex gym (no flag means false))
 ### Invasion icons
-  - invasion: `<grunt id>.png`
+  - invasion: `<grunt id>[_i{incident_display_type}].png`
 ### Pokestop icons
-  - pokestop: `<lure id**>[_i][_q{with_ar}][_ar].png` ( `_i` invasion active, `_q` quest active, `_ar` ar eligible ) images from invasion and reward folder can be used as overlay
+  - pokestop: `<lure id**>[_i{incident_display_type}][_q{with_ar}][_ar].png` ( `_i` incident active, `_q` quest active, `_ar` ar eligible ) images from `invasion` and `reward` folders can be used as overlay
   - ** Not lured is ID `0` further follow proto's
   - Upcoming Pokestop levels might change perspective on pokestop icon naming.. TBC
-  - `_q`: any or both AR and non-AR quests are active 
+  - `_q`: Any or both AR and non-AR quests are active
   - `_q0`: Non-AR quest active
   - `_q1`: AR quest active
+  - `_i`: Default incident active (Team Rocket)
+  - `_i7`: Type 7 incident active (Gold Pokestop)
 ### Team Icons
   - team: `<team id>.png` (Team badges not to be confused with Gym icons)
 ### Type Icons


### PR DESCRIPTION
### Motivation
With the introduction of Gold Stops, Pokéstop now have incidents that are not exclusively invasions.

### Changes
- Pokéstop icons: Extend key from `[_i]` to `[_i{incident_display_type}]` and the term «invasion» is replaced with «incident» which includes them and all other incident types.
- Invasion icons: Add a new key `[_i{incident_display_type}]` to allow for custom per incident type icons.
- Those changes are backward compatible with existing icon repositories (see examples).

### Example - Pokéstop icons
- Pokéstop with Gio (type 3 incident).
  - `0_i3.png` does not exists and falls back to `0_i.png` which exists and the same image as currently used.
- Gold Pokéstop (type 7 incident)
  - `0_i7.png` can now be used.

### Example - Invasion icons
- Gio (character 44, type 3):
  - `44_i3.png` does not exists and falls back to `44_i.png` which does not exists and falls back to `44.png` which exists and the same image as currently used.