### PR TITLE
Dynamax support for Pokemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
 
 ### Pokemon icons
 
-  - `<pokemon id>[_e{temp evolution id}][_f{form id}][_c{costume id}][_g{gender id}][_a{alignment_id}][_s{shiny}].png`
+  - `<pokemon id>[_e{temp evolution id}][_f{form id}][_c{costume id}][_g{gender id}][_a{alignment_id}][_b{bread mode id}][_s{shiny}].png`
     - Example: `3.png` Regular Venusaur
     - Example: `3_e1_s.png` Mega Venusaur Shiny
     - Example: `3_f950.png` Venusaur Clone Form
     - Example: `3_a1.png` Shadow Venusaur
+    - Example: `3_b1.png` Dynamax Venusaur
 
 ### Reward icons
   - item: `<item id>[_a{amount}].png`


### PR DESCRIPTION
There's a new enum that seems to indicate dynamax pokemon. It sits on the PokemonDisplayProto:

```
message BreadModeEnum {
	enum Modifier {
		NONE = 0;
		BREAD_MODE = 1;
		BREAD_DOUGH_MODE = 2;
		BREAD_DOUGH_MODE_2 = 3;
	}
}
```

Bread Mode seems to be the internal name for dynamax pokemon, and Bread Dough Mode might be Gigantamax. I'm not entirely sure.

The proposoal is to add `_b{id}` to the pokemon format. I wouldn't mind using `_d` (for dynamax) instead, but `_b` would be more aligned with the protos.